### PR TITLE
Fix method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 ```ruby
 # Creates a new workbook and closes it at the end of the block.
 Xlsxtream::Workbook.open("foo.xlsx") do |xlsx|
-  xlsx.write_sheet "Sheet1" do |sheet|
+  xlsx.write_worksheet "Sheet1" do |sheet|
     # Date, Time, DateTime, Fixnum & Float are properly mapped
     sheet << [Date.today, "hello", "world", 42, 3.14159265359]
   end


### PR DESCRIPTION
In #2 there was a line in the README where a method name was missed on updating.