### PR TITLE
Implement ST_Xstring escaping of invalud xml chars

### DIFF
--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -14,6 +14,13 @@ module Xlsxtream
     UNSAFE_ATTR_CHARS = /[&"<>]/.freeze
     UNSAFE_VALUE_CHARS = /[&<>]/.freeze
 
+    # http://www.w3.org/TR/REC-xml/#NT-Char:
+    # Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    INVALID_XML10_CHARS = /[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/.freeze
+
+    # ST_Xstring escaping
+    ESCAPE_CHAR = lambda { |c| '_x%04x_'.freeze % c.ord }.freeze
+
     class << self
 
       def header
@@ -29,7 +36,7 @@ module Xlsxtream
       end
 
       def escape_value(string)
-        string.gsub(UNSAFE_VALUE_CHARS, XML_ESCAPES)
+        string.gsub(UNSAFE_VALUE_CHARS, XML_ESCAPES).gsub(INVALID_XML10_CHARS, &ESCAPE_CHAR)
       end
 
     end

--- a/test/xlsxtream/xml_test.rb
+++ b/test/xlsxtream/xml_test.rb
@@ -29,5 +29,11 @@ module Xlsxtream
       expected = '&lt;hello&gt; &amp; "world"'
       assert_equal expected, XML.escape_value(unsafe_value)
     end
+
+    def test_escape_value_invalid_xml_chars
+      unsafe_value = "The \x07 rings\x00\uFFFE\uFFFF"
+      expected = 'The _x0007_ rings_x0000__xfffe__xffff_'
+      assert_equal expected, XML.escape_value(unsafe_value)
+    end
   end
 end


### PR DESCRIPTION
This escapes invalud XML 1.0 characters using the ST_Xstring encoding, which uses the Unicode numerical character representation format `_xHHHH_`, where HHHH is the hex-encoded character value.

Fixes #9