### PR TITLE
Don't close IOs passed to Workbook constructor

### DIFF
--- a/lib/xlsxtream/io/rubyzip.rb
+++ b/lib/xlsxtream/io/rubyzip.rb
@@ -4,9 +4,9 @@ module Xlsxtream
   module IO
     class RubyZip
       def initialize(path_or_io)
-        stream = path_or_io.respond_to? :reopen
+        @stream = path_or_io.respond_to? :reopen
         path_or_io.binmode if path_or_io.respond_to? :binmode
-        @zos = UnbufferedZipOutputStream.new(path_or_io, stream)
+        @zos = UnbufferedZipOutputStream.new(path_or_io, @stream)
       end
 
       def <<(data)
@@ -20,7 +20,7 @@ module Xlsxtream
       def close
         os = @zos.close_buffer
         os.flush if os.respond_to? :flush
-        os.close if os.respond_to? :close
+        os.close if !@stream and os.respond_to? :close
       end
 
       # Extend get_compressor to hook our custom deflater.

--- a/test/xlsxtream/workbook_test.rb
+++ b/test/xlsxtream/workbook_test.rb
@@ -234,6 +234,14 @@ module Xlsxtream
       assert_equal expected, actual
     end
 
+    def test_tempfile_is_not_closed
+      tempfile = Tempfile.new('workbook')
+      Workbook.open(tempfile) {}
+      assert_equal false, tempfile.closed?
+    ensure
+      tempfile && tempfile.close!
+    end
+
     private
 
     def io_wrapper_spy


### PR DESCRIPTION
If Xlsxtream does not own the IO object that is used to write the XLSX ZIP file, it will no longer try to close it.

Fixes #6