### PR TITLE
Support customizing font name, size, family

### DIFF
--- a/lib/xlsxtream/errors.rb
+++ b/lib/xlsxtream/errors.rb
@@ -1,0 +1,3 @@
+module Xlsxtream
+  class Error < StandardError; end
+end

--- a/test/xlsxtream/workbook_test.rb
+++ b/test/xlsxtream/workbook_test.rb
@@ -253,6 +253,63 @@ module Xlsxtream
       assert_equal expected, actual
     end
 
+    def test_custom_font_size
+      iow_spy = io_wrapper_spy
+      font_options = { :size => 23 }
+      Workbook.open(nil, :io_wrapper => iow_spy, :font => font_options) {}
+      expected = '<sz val="23"/>'
+      actual = iow_spy['xl/styles.xml'][/<sz [^>]+>/]
+      assert_equal expected, actual
+    end
+
+    def test_custom_font_name
+      iow_spy = io_wrapper_spy
+      font_options = { :name => 'Comic Sans' }
+      Workbook.open(nil, :io_wrapper => iow_spy, :font => font_options) {}
+      expected = '<name val="Comic Sans"/>'
+      actual = iow_spy['xl/styles.xml'][/<name [^>]+>/]
+      assert_equal expected, actual
+    end
+
+    def test_custom_font_family
+      iow_spy = io_wrapper_spy
+      font_options = { :family => 'Script' }
+      Workbook.open(nil, :io_wrapper => iow_spy, :font => font_options) {}
+      expected = '<family val="4"/>'
+      actual = iow_spy['xl/styles.xml'][/<family [^>]+>/]
+      assert_equal expected, actual
+    end
+
+    def test_font_family_mapping
+      tests = {
+        nil => 0,
+        ''  => 0,
+        'ROMAN' => 1,
+        :roman => 1,
+        'Roman' => 1,
+        :swiss => 2,
+        :modern => 3,
+        :script => 4,
+        :decorative => 5
+      }
+      tests.each do |value, id|
+        iow_spy = io_wrapper_spy
+        font_options = { :family => value }
+        Workbook.open(nil, :io_wrapper => iow_spy, :font => font_options) {}
+        expected = "<family val=\"#{id}\"/>"
+        actual = iow_spy['xl/styles.xml'][/<family [^>]+>/]
+        assert_equal expected, actual
+      end
+    end
+
+    def test_invalid_font_family
+      iow_spy = io_wrapper_spy
+      font_options = { :family => 'Foo' }
+      assert_raises Xlsxtream::Error do
+        Workbook.open(nil, :io_wrapper => iow_spy, :font => font_options) {}
+      end
+    end
+
     def test_tempfile_is_not_closed
       tempfile = Tempfile.new('workbook')
       Workbook.open(tempfile) {}


### PR DESCRIPTION
This adds support for overriding the default font settings for the whole workbook.

The default settings are:

```ruby
{ font: { name: 'Calibri', size: 12, family: 'Swiss' } }
```

Example with Arial 10pt:

```ruby
Xlsxtream::Workbook.new('foo.xlsx', font: { name: 'Arial', size: 10 })
```

Resolves #15