### PR TITLE
Refactor IO Wrappers

### DIFF
--- a/lib/xlsxtream/io/rubyzip.rb
+++ b/lib/xlsxtream/io/rubyzip.rb
@@ -1,12 +1,16 @@
 require "zip"
+require "xlsxtream/errors"
 
 module Xlsxtream
   module IO
     class RubyZip
-      def initialize(path_or_io)
-        @stream = path_or_io.respond_to? :reopen
-        path_or_io.binmode if path_or_io.respond_to? :binmode
-        @zos = Zip::OutputStream.new(path_or_io, @stream)
+      def initialize(io)
+        unless io.respond_to? :pos and io.respond_to? :pos=
+          raise Error, 'IO is not seekable'
+        end
+        io.binmode if io.respond_to? :binmode
+        stream = true
+        @zos = Zip::OutputStream.new(io, stream)
       end
 
       def <<(data)
@@ -20,7 +24,6 @@ module Xlsxtream
       def close
         os = @zos.close_buffer
         os.flush if os.respond_to? :flush
-        os.close if !@stream and os.respond_to? :close
       end
     end
   end

--- a/lib/xlsxtream/workbook.rb
+++ b/lib/xlsxtream/workbook.rb
@@ -4,8 +4,6 @@ require "xlsxtream/xml"
 require "xlsxtream/shared_string_table"
 require "xlsxtream/workbook"
 require "xlsxtream/io/rubyzip"
-require "xlsxtream/io/directory"
-require "xlsxtream/io/stream"
 
 module Xlsxtream
   class Workbook

--- a/test/xlsxtream/io/directory_test.rb
+++ b/test/xlsxtream/io/directory_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'xlsxtream/io/directory'
+require 'pathname'
+
+module Xlsxtream
+  module IO
+    class DirectoryTest < Minitest::Test
+
+      def test_writes_of_multiple_files
+        Dir.mktmpdir do |dir|
+          io = Xlsxtream::IO::Directory.new(dir)
+          io.add_file("book1.xml")
+          io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />'
+          io.add_file("book2.xml")
+          io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook>'
+          io << '</workbook>'
+          io.add_file("empty.txt")
+          io.add_file("another.xml")
+          io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />'
+          io.close
+
+          dir = Pathname(dir)
+          assert_equal '', dir.join('empty.txt').read
+          assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />', dir.join('book1.xml').read
+          assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook></workbook>', dir.join('book2.xml').read
+          assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />', dir.join('another.xml').read
+        end
+
+      end
+    end
+  end
+end

--- a/test/xlsxtream/io/hash_test.rb
+++ b/test/xlsxtream/io/hash_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+require 'xlsxtream/io/hash'
+
+module Xlsxtream
+  module IO
+    class HashTest < Minitest::Test
+
+      def test_writes_of_multiple_files
+        buffer = StringIO.new
+
+        io = Xlsxtream::IO::Hash.new(buffer)
+        io.add_file("book1.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />'
+        io.add_file("book2.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook>'
+        io << '</workbook>'
+        io.add_file("empty.txt")
+        io.add_file("another.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />'
+        io.close
+
+        file_contents = io.to_h
+        assert_equal '', file_contents['empty.txt']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />', file_contents['book1.xml']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook></workbook>', file_contents['book2.xml']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />', file_contents['another.xml']
+      end
+    end
+  end
+end

--- a/test/xlsxtream/io/rubyzip_test.rb
+++ b/test/xlsxtream/io/rubyzip_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'xlsxtream/io/rubyzip'
+require 'zip'
+
+module Xlsxtream
+  module IO
+    class RubyZipTest < Minitest::Test
+
+      def test_writes_of_multiple_files
+        zip_buf = Tempfile.new('ztio-test')
+
+        io = Xlsxtream::IO::RubyZip.new(zip_buf)
+        io.add_file("book1.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />'
+        io.add_file("book2.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook>'
+        io << '</workbook>'
+        io.add_file("empty.txt")
+        io.add_file("another.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />'
+        io.close
+
+        zip_buf.rewind
+
+        file_contents = {}
+        ::Zip::File.open(zip_buf) do |zip_file|
+          zip_file.each do |entry|
+            file_contents[entry.name] = entry.get_input_stream.read
+          end
+        end
+        assert_equal '', file_contents['empty.txt']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />', file_contents['book1.xml']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook></workbook>', file_contents['book2.xml']
+        assert_equal '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />', file_contents['another.xml']
+      ensure
+        zip_buf.close! if zip_buf
+      end
+    end
+  end
+end

--- a/test/xlsxtream/io/stream_test.rb
+++ b/test/xlsxtream/io/stream_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'xlsxtream/io/stream'
+
+module Xlsxtream
+  module IO
+    class StreamTest < Minitest::Test
+
+      def test_writes_of_multiple_files
+        buffer = StringIO.new
+
+        io = Xlsxtream::IO::Stream.new(buffer)
+        io.add_file("book1.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />'
+        io.add_file("book2.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook>'
+        io << '</workbook>'
+        io.add_file("empty.txt")
+        io.add_file("another.xml")
+        io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />'
+        io.close
+
+        file_contents = buffer.string
+        assert_equal <<-EOF, file_contents
+book1.xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />
+book2.xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook></workbook>
+empty.txt
+
+another.xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><another />
+EOF
+      end
+    end
+  end
+end

--- a/test/xlsxtream/workbook_test.rb
+++ b/test/xlsxtream/workbook_test.rb
@@ -1,9 +1,26 @@
 require 'test_helper'
+require 'tempfile'
 require 'xlsxtream/workbook'
 require 'xlsxtream/io/hash'
 
 module Xlsxtream
   class WorksheetTest < Minitest::Test
+
+    def test_workbook_from_path
+      tempfile = Tempfile.new('xlsxtream')
+      Workbook.open(tempfile.path) {}
+      refute_equal 0, tempfile.size
+    ensure
+      tempfile.close! if tempfile
+    end
+
+    def test_workbook_from_io
+      tempfile = Tempfile.new('xlsxtream')
+      Workbook.open(tempfile) {}
+      refute_equal 0, tempfile.size
+    ensure
+      tempfile.close! if tempfile
+    end
 
     def test_empty_workbook
       iow_spy = io_wrapper_spy


### PR DESCRIPTION
* Add tests for creating workbooks from path and IOs
* Extract path handling from RubyZip IO wrapper
* Add tests for IO wrappers
* Don't load debug IO wrappers by default