### PR TITLE
Remove custom unbuffered RubyZip output stream

### DIFF
--- a/lib/xlsxtream/io/rubyzip.rb
+++ b/lib/xlsxtream/io/rubyzip.rb
@@ -6,7 +6,7 @@ module Xlsxtream
       def initialize(path_or_io)
         @stream = path_or_io.respond_to? :reopen
         path_or_io.binmode if path_or_io.respond_to? :binmode
-        @zos = UnbufferedZipOutputStream.new(path_or_io, @stream)
+        @zos = Zip::OutputStream.new(path_or_io, @stream)
       end
 
       def <<(data)
@@ -21,47 +21,6 @@ module Xlsxtream
         os = @zos.close_buffer
         os.flush if os.respond_to? :flush
         os.close if !@stream and os.respond_to? :close
-      end
-
-      # Extend get_compressor to hook our custom deflater.
-      class UnbufferedZipOutputStream < ::Zip::OutputStream
-        private
-        def get_compressor(entry, level)
-          case entry.compression_method
-          when ::Zip::Entry::DEFLATED then
-            StreamingDeflater.new(@output_stream, level, @encrypter)
-          else
-            super
-          end
-        end
-      end
-
-      # RubyZip's Deflater buffers to a StringIO until finish is called.
-      # This StreamingDeflater writes out chunks during compression.
-      class StreamingDeflater < ::Zip::Compressor
-        def initialize(output_stream, level = Zip.default_compression, encrypter = NullEncrypter.new)
-          super()
-          @output_stream = output_stream
-          @zlib_deflater = ::Zlib::Deflate.new(level, -::Zlib::MAX_WBITS)
-          @size          = 0
-          @crc           = ::Zlib.crc32
-          unless encrypter.is_a? ::Zip::NullEncrypter
-            raise ::Zip::Error, 'StreamingDeflater does not support encryption'
-          end
-        end
-
-        def <<(data)
-          val   = data.to_s
-          @crc  = Zlib.crc32(val, @crc)
-          @size += val.bytesize
-          @output_stream << @zlib_deflater.deflate(data)
-        end
-
-        def finish
-          @output_stream << @zlib_deflater.finish until @zlib_deflater.finished?
-        end
-
-        attr_reader :size, :crc
       end
     end
   end

--- a/xlsxtream.gemspec
+++ b/xlsxtream.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 1.9.1'
+  spec.required_ruby_version = '>= 1.9.2'
 
-  spec.add_dependency "rubyzip", ">= 1.0.0"
+  spec.add_dependency "rubyzip", ">= 1.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The `UnbufferedZipOutputStream` implementation worked around an issue in RubyZip that has been fixed since version v1.2.0, so we instead depend on this version.

Because the required RubyZip version depends on Ruby 1.9.2, we also raise out requirement to 1.9.2.

For details on the changes to RubyZip see: https://github.com/rubyzip/rubyzip/commit/7a4b8bb048fca6f1fedc970d0d6dd61e6368e2ec