### PR TITLE
Deprecate :io_wrapper option, autodetect wrappers

### DIFF
--- a/lib/xlsxtream/errors.rb
+++ b/lib/xlsxtream/errors.rb
@@ -1,3 +1,4 @@
 module Xlsxtream
   class Error < StandardError; end
+  class Deprecation < StandardError; end
 end

--- a/test/xlsxtream/io/hash_test.rb
+++ b/test/xlsxtream/io/hash_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 require 'xlsxtream/io/hash'
 
 module Xlsxtream

--- a/test/xlsxtream/io/stream_test.rb
+++ b/test/xlsxtream/io/stream_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 require 'xlsxtream/io/stream'
 
 module Xlsxtream
@@ -20,7 +21,7 @@ module Xlsxtream
         io.close
 
         file_contents = buffer.string
-        assert_equal <<-EOF, file_contents
+        assert_equal(<<-EOF, file_contents)
 book1.xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />
 book2.xml

--- a/test/xlsxtream/worksheet_test.rb
+++ b/test/xlsxtream/worksheet_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 require 'xlsxtream/worksheet'
 
 module Xlsxtream


### PR DESCRIPTION
Any IO-like object that implements `:add_file` is a compatible IO wrapper and used directly.

Other IO-like objects are wrapped with the default ZipTricks IO wrapper.

This makes it possible to use IO wrappers that need external data and removes the need for the hacky IO wrapper spy used in the tests.

With this change the output parameter to the Workbook constructor is no longer optional, because the default behavior of falling back to a `StringIO` instance in that case didn't make any sense, since there was no way to access the generated XLSX.