### PR TITLE
Buffer 64k in ZipTricks IO to improve performance

### DIFF
--- a/lib/xlsxtream/io/zip_tricks.rb
+++ b/lib/xlsxtream/io/zip_tricks.rb
@@ -3,24 +3,41 @@ require "zip_tricks"
 module Xlsxtream
   module IO
     class ZipTricks
+      BUFFER_SIZE = 64 * 1024
+
       def initialize(body)
         @streamer = ::ZipTricks::Streamer.new(body)
         @wf = nil
+        @buffer = ''
       end
 
       def <<(data)
-        @wf << data
+        @buffer << data
+        flush_buffer if @buffer.size >= BUFFER_SIZE
         self
       end
 
       def add_file(path)
-        @wf.close if @wf
+        flush_file
         @wf = @streamer.write_deflated_file(path)
       end
 
       def close
-        @wf.close if @wf
+        flush_file
         @streamer.close
+      end
+
+      private
+
+      def flush_buffer
+        @wf << @buffer
+        @buffer.clear
+      end
+
+      def flush_file
+        return unless @wf
+        flush_buffer if @buffer.size > 0
+        @wf.close
       end
     end
   end


### PR DESCRIPTION
The zip_tricks gem uses less internal buffering than RubyZip, so we need to do some buffering of our own to get equal or better performance than with the RubyZip IO for small rows.

With this change the ZipTricks IO is about 1.35x as fast as the RubyZip IO, while it used to be about 0.4x without buffering on zip_tricks 4.5.0 and about the same speed as rubyzip on 4.5.1, which adds buffering to the streaming CRC32 calculation.