### PR TITLE
Rescue gracefully from invalid dates

### DIFF
--- a/lib/xlsxtream/row.rb
+++ b/lib/xlsxtream/row.rb
@@ -77,9 +77,9 @@ module Xlsxtream
       when NUMBER_PATTERN
         value.include?('.') ? value.to_f : value.to_i
       when DATE_PATTERN
-        Date.parse(value)
+        Date.parse(value) rescue value
       when TIME_PATTERN
-        DateTime.parse(value)
+        DateTime.parse(value) rescue value
       else
         value
       end


### PR DESCRIPTION
For example, the string '2018-02-29' will match `DATE_PATTERN` but `Date.parse` will throw an ArgumentError when parsing the string.

Returning value instead yields the same result as a much more complicated regular expression would (regexps that takes leap years into account are needlessly complicated).

@felixbuenemann Let me know what you think!