### PR TITLE
Column widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.0 (2018-07-11)
 
-- New `#add_columns` interface, allowing column widths to be specified
+- New `:columns` option, allowing column widths to be specified
 
 ## 2.0.1 (2018-03-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 (2018-07-11)
+
+- New `#add_columns` interface, allowing column widths to be specified
+
 ## 2.0.1 (2018-03-11)
 
 - Rescue gracefully from invalid dates with auto-format (#22)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,17 @@ Xlsxtream::Workbook.new(io, font: {
   family: 'Roman' # Swiss, Modern, Script, Decorative
 })
 
+# Specifying column widths in pixels or characters; 3 column example;
+# "pixel" widths appear to be *relative* to an assumed 11pt Calibri
+# font, so if selecting a different font or size (see above), do not
+# adjust widths to match. Calculate pixel widths for 11pt Calibri.
+Xlsxtream::Workbook.new(io, columns: [
+  { width_pixels: 33 },
+  { width_chars: 7 },
+  { width_chars: 24 }
+])
 ```
+
 
 ## Compatibility
 

--- a/lib/xlsxtream.rb
+++ b/lib/xlsxtream.rb
@@ -5,4 +5,5 @@ end
 
 require "xlsxtream/workbook"
 require "xlsxtream/worksheet"
+require "xlsxtream/columns"
 require "xlsxtream/row"

--- a/lib/xlsxtream/columns.rb
+++ b/lib/xlsxtream/columns.rb
@@ -1,0 +1,54 @@
+# encoding: utf-8
+require "xlsxtream/xml"
+
+module Xlsxtream
+  class Columns
+
+    ENCODING = Encoding.find('UTF-8')
+
+    # Pass an Array of column options Hashes. Symbol Hash keys and associated
+    # values are as follows:
+    #
+    # +width_chars+::  Approximate column with in characters, calculated per
+    #                  MSDN docs as if using a default 11 point Calibri font
+    #                  for a 96 DPI target. Specify as an integer.
+    #
+    # +width_pixels+:: Exact with of column in pixels. Specify as a Float.
+    #                  Overrides +width_chars+ if that is also provided.
+    #
+    def initialize(column_options_array)
+      @columns = column_options_array
+    end
+
+    def to_xml
+      xml = '<cols>'
+
+      @columns.each_with_index do |column, index|
+        width_chars  = column[ :width_chars  ]
+        width_pixels = column[ :width_pixels ]
+
+        if width_chars.nil? && width_pixels.nil?
+          xml << %Q{<col min="#{index + 1}" max="#{index + 1}"/>}
+        else
+
+          # https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.column.aspx
+          #
+          # Truncate(
+          #   [{Number of Characters} * {Maximum Digit Width} + {5 pixel padding}]
+          #   /{Maximum Digit Width}*256
+          # )/256
+          #
+          # "Using the Calibri font as an example, the maximum digit width of
+          #  11 point font size is 7 pixels (at 96 dpi)"
+          #
+          width_pixels ||= ((((width_chars * 7.0) + 5) / 7) * 256).truncate() / 256.0
+
+          xml << %Q{<col min="#{index + 1}" max="#{index + 1}" width="#{width_pixels}" customWidth="1"/>}
+        end
+      end
+
+      xml << '</cols>'
+    end
+
+  end
+end

--- a/lib/xlsxtream/columns.rb
+++ b/lib/xlsxtream/columns.rb
@@ -41,6 +41,13 @@ module Xlsxtream
           # "Using the Calibri font as an example, the maximum digit width of
           #  11 point font size is 7 pixels (at 96 dpi)"
           #
+          # By observation, though, I note that a different spreadsheet-wide
+          # font size selected via the Workbook's ":font => { :size => ... }"
+          # options Hash entry results in Excel, at least, scaling the given
+          # widths in proportion with the requested font size change. We do
+          # not, apparently, need to do that ourselves and run the calculation
+          # based on the reference 11 point -> 7 pixel figure.
+          #
           width_pixels ||= ((((width_chars * 7.0) + 5) / 7) * 256).truncate() / 256.0
 
           xml << %Q{<col min="#{index + 1}" max="#{index + 1}" width="#{width_pixels}" customWidth="1"/>}

--- a/lib/xlsxtream/version.rb
+++ b/lib/xlsxtream/version.rb
@@ -1,3 +1,3 @@
 module Xlsxtream
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/lib/xlsxtream/workbook.rb
+++ b/lib/xlsxtream/workbook.rb
@@ -65,13 +65,14 @@ module Xlsxtream
       end
       use_sst = options.fetch(:use_shared_strings, @options[:use_shared_strings])
       auto_format = options.fetch(:auto_format, @options[:auto_format])
+      columns = options.fetch(:columns, @options[:columns])
       sst = use_sst ? @sst : nil
 
       name ||= "Sheet#{@worksheets.size + 1}"
       sheet_id = @worksheets[name]
       @io.add_file "xl/worksheets/sheet#{sheet_id}.xml"
 
-      worksheet = Worksheet.new(@io, :sst => sst, :auto_format => auto_format)
+      worksheet = Worksheet.new(@io, :sst => sst, :auto_format => auto_format, :columns => columns)
       yield worksheet if block_given?
       worksheet.close
 

--- a/lib/xlsxtream/worksheet.rb
+++ b/lib/xlsxtream/worksheet.rb
@@ -46,6 +46,11 @@ module Xlsxtream
     end
 
     def write_footer
+      unless @sheetdata_written
+        @sheetdata_written = true
+        @io << '<sheetData>'
+      end
+
       @io << XML.strip(<<-XML)
           </sheetData>
         </worksheet>

--- a/lib/xlsxtream/worksheet.rb
+++ b/lib/xlsxtream/worksheet.rb
@@ -8,25 +8,11 @@ module Xlsxtream
       @io = io
       @rownum = 1
       @options = options
-      @sheetdata_written = false
 
       write_header
     end
 
-    # If you want to specify custom column widths, do so using this
-    # method. See Xlsstream::Columns#initialize for parameter details.
-    # This MUST be called before #add_row or #<<.
-    #
-    def add_columns(column_options_array)
-      @io << Columns.new(column_options_array).to_xml
-    end
-
     def <<(row)
-      unless @sheetdata_written
-        @sheetdata_written = true
-        @io << '<sheetData>'
-      end
-
       @io << Row.new(row, @rownum, @options).to_xml
       @rownum += 1
     end
@@ -43,14 +29,18 @@ module Xlsxtream
       @io << XML.strip(<<-XML)
         <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
       XML
+
+      columns = @options[:columns]
+      if columns.is_a?(Array)
+        @io << Columns.new(columns).to_xml
+      end
+
+      @io << XML.strip(<<-XML)
+          <sheetData>
+      XML
     end
 
     def write_footer
-      unless @sheetdata_written
-        @sheetdata_written = true
-        @io << '<sheetData>'
-      end
-
       @io << XML.strip(<<-XML)
           </sheetData>
         </worksheet>

--- a/lib/xlsxtream/worksheet.rb
+++ b/lib/xlsxtream/worksheet.rb
@@ -30,8 +30,8 @@ module Xlsxtream
         <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
       XML
 
-      columns = @options[:columns]
-      if columns.is_a?(Array)
+      columns = Array(@options[:columns])
+      unless columns.empty?
         @io << Columns.new(columns).to_xml
       end
 

--- a/lib/xlsxtream/worksheet.rb
+++ b/lib/xlsxtream/worksheet.rb
@@ -8,11 +8,25 @@ module Xlsxtream
       @io = io
       @rownum = 1
       @options = options
+      @sheetdata_written = false
 
       write_header
     end
 
+    # If you want to specify custom column widths, do so using this
+    # method. See Xlsstream::Columns#initialize for parameter details.
+    # This MUST be called before #add_row or #<<.
+    #
+    def add_columns(column_options_array)
+      @io << Columns.new(column_options_array).to_xml
+    end
+
     def <<(row)
+      unless @sheetdata_written
+        @sheetdata_written = true
+        @io << '<sheetData>'
+      end
+
       @io << Row.new(row, @rownum, @options).to_xml
       @rownum += 1
     end
@@ -28,7 +42,6 @@ module Xlsxtream
       @io << XML.header
       @io << XML.strip(<<-XML)
         <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-          <sheetData>
       XML
     end
 

--- a/test/xlsxtream/columns_test.rb
+++ b/test/xlsxtream/columns_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+require 'xlsxtream/row'
+
+module Xlsxtream
+  class ColumnsTest < Minitest::Test
+    def test_no_width_column
+      column = Columns.new( [ {} ] )
+      expected = '<cols><col min="1" max="1"/></cols>'
+      actual = column.to_xml
+      assert_equal expected, actual
+    end
+
+    def test_pixel_width_column
+      column = Columns.new( [ { :width_pixels => 2341.5 } ] )
+      expected = '<cols><col min="1" max="1" width="2341.5" customWidth="1"/></cols>'
+      actual = column.to_xml
+      assert_equal expected, actual
+    end
+
+    def test_character_width_column
+
+      # https://msdn.microsoft.com/en-us/library/office/documentformat.openxml.spreadsheet.column.aspx
+      #
+      # ...Therefore, if the cell width is 8 characters wide, the value of
+      # this attribute must be Truncate([8*7+5]/7*256)/256 = 8.7109375...
+      #
+      column = Columns.new( [ { :width_chars => 8 } ] )
+      expected = '<cols><col min="1" max="1" width="8.7109375" customWidth="1"/></cols>'
+
+      actual = column.to_xml
+      assert_equal expected, actual
+    end
+
+    def test_mixed_columns
+      column = Columns.new( [ {}, { :width_pixels => 61 }, { :width_chars => 14 } ] )
+      expected = '<cols><col min="1" max="1"/><col min="2" max="2" width="61" customWidth="1"/><col min="3" max="3" width="14.7109375" customWidth="1"/></cols>'
+      actual = column.to_xml
+      assert_equal expected, actual
+    end
+  end
+end

--- a/test/xlsxtream/workbook_test.rb
+++ b/test/xlsxtream/workbook_test.rb
@@ -225,6 +225,50 @@ module Xlsxtream
       assert_equal expected, actual
     end
 
+    def test_add_columns_via_workbook_options
+      iow_spy = io_wrapper_spy
+      Workbook.open(iow_spy, { :columns => [ {}, {}, { :width_pixels => 42 } ] } ) do |wb|
+        wb.add_worksheet {}
+      end
+
+      expected = \
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
+          '<col min="1" max="1"/>' \
+          '<col min="2" max="2"/>' \
+          '<col min="3" max="3" width="42" customWidth="1"/>' \
+        '</cols>' \
+        '<sheetData></sheetData></worksheet>'
+
+      actual = iow_spy['xl/worksheets/sheet1.xml']
+      assert_equal expected, actual
+    end
+
+    def test_add_columns_via_workbook_options_and_add_rows
+      iow_spy = io_wrapper_spy
+      Workbook.open(iow_spy, { :columns => [ {}, {}, { :width_pixels => 42 } ] } ) do |wb|
+        wb.add_worksheet do |ws|
+          ws << ['foo']
+          ws.add_row ['bar']
+        end
+      end
+
+      expected = \
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
+          '<col min="1" max="1"/>' \
+          '<col min="2" max="2"/>' \
+          '<col min="3" max="3" width="42" customWidth="1"/>' \
+        '</cols>' \
+        '<sheetData>' \
+          '<row r="1"><c r="A1" t="inlineStr"><is><t>foo</t></is></c></row>' \
+          '<row r="2"><c r="A2" t="inlineStr"><is><t>bar</t></is></c></row>' \
+        '</sheetData></worksheet>'
+
+      actual = iow_spy['xl/worksheets/sheet1.xml']
+      assert_equal expected, actual
+    end
+
     def test_styles_content
       iow_spy = io_wrapper_spy
       Workbook.open(iow_spy) {}

--- a/test/xlsxtream/worksheet_test.rb
+++ b/test/xlsxtream/worksheet_test.rb
@@ -14,22 +14,6 @@ module Xlsxtream
       assert_equal expected, io.string
     end
 
-    def test_add_columns
-      io = StringIO.new
-      ws = Worksheet.new(io)
-      ws.add_columns( [ {}, {}, { :width_pixels => 42 } ] )
-      ws.close
-      expected = \
-        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
-        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
-          '<col min="1" max="1"/>' \
-          '<col min="2" max="2"/>' \
-          '<col min="3" max="3" width="42" customWidth="1"/>' \
-        '</cols>' \
-        '<sheetData></sheetData></worksheet>'
-      assert_equal expected, io.string
-    end
-
     def test_add_row
       io = StringIO.new
       ws = Worksheet.new(io)
@@ -72,10 +56,24 @@ module Xlsxtream
       assert_equal expected, io.string
     end
 
-    def test_add_columns_and_row
+    def test_add_columns_via_worksheet_options
       io = StringIO.new
-      ws = Worksheet.new(io)
-      ws.add_columns( [ {}, {}, { :width_pixels => 42 } ] )
+      ws = Worksheet.new(io, { :columns => [ {}, {}, { :width_pixels => 42 } ] } )
+      ws.close
+      expected = \
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
+          '<col min="1" max="1"/>' \
+          '<col min="2" max="2"/>' \
+          '<col min="3" max="3" width="42" customWidth="1"/>' \
+        '</cols>' \
+        '<sheetData></sheetData></worksheet>'
+      assert_equal expected, io.string
+    end
+
+    def test_add_columns_via_worksheet_options_and_add_rows
+      io = StringIO.new
+      ws = Worksheet.new(io, { :columns => [ {}, {}, { :width_pixels => 42 } ] } )
       ws << ['foo']
       ws.add_row ['bar']
       ws.close

--- a/test/xlsxtream/worksheet_test.rb
+++ b/test/xlsxtream/worksheet_test.rb
@@ -14,6 +14,22 @@ module Xlsxtream
       assert_equal expected, io.string
     end
 
+    def test_add_columns
+      io = StringIO.new
+      ws = Worksheet.new(io)
+      ws.add_columns( [ {}, {}, { :width_pixels => 42 } ] )
+      ws.close
+      expected = \
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
+          '<col min="1" max="1"/>' \
+          '<col min="2" max="2"/>' \
+          '<col min="3" max="3" width="42" customWidth="1"/>' \
+        '</cols>' \
+        '<sheetData></sheetData></worksheet>'
+      assert_equal expected, io.string
+    end
+
     def test_add_row
       io = StringIO.new
       ws = Worksheet.new(io)
@@ -52,6 +68,27 @@ module Xlsxtream
         '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
         '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>' \
           '<row r="1"><c r="A1" t="n"><v>1.5</v></c></row>' \
+        '</sheetData></worksheet>'
+      assert_equal expected, io.string
+    end
+
+    def test_add_columns_and_row
+      io = StringIO.new
+      ws = Worksheet.new(io)
+      ws.add_columns( [ {}, {}, { :width_pixels => 42 } ] )
+      ws << ['foo']
+      ws.add_row ['bar']
+      ws.close
+      expected = \
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'"\r\n" \
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><cols>' \
+          '<col min="1" max="1"/>' \
+          '<col min="2" max="2"/>' \
+          '<col min="3" max="3" width="42" customWidth="1"/>' \
+        '</cols>' \
+        '<sheetData>' \
+          '<row r="1"><c r="A1" t="inlineStr"><is><t>foo</t></is></c></row>' \
+          '<row r="2"><c r="A2" t="inlineStr"><is><t>bar</t></is></c></row>' \
         '</sheetData></worksheet>'
       assert_equal expected, io.string
     end


### PR DESCRIPTION
I wanted to be able to specify column widths by pixel or character in Excel output. The purpose of the gem is to stream out data, so the idea of scanning every source data row in an attempt to get the maximum column width needed to cover all rows is obviously not tenable. However, we can often either know some of the widths up front (e.g. contains a date-time, or a UUID, or whatever), or we might get useful initial width estimations from just the first few rows of data, computing that up-front before streaming out the spreadsheet. It's this latter approach that I've just used in a Rails application that's streaming data out via the gem fork I've built.