### PR TITLE
Work with --enable-frozen-string-literal

### DIFF
--- a/lib/xlsxtream.rb
+++ b/lib/xlsxtream.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "xlsxtream/version"
 
 module Xlsxtream

--- a/lib/xlsxtream/columns.rb
+++ b/lib/xlsxtream/columns.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-
+# frozen_string_literal: true
 module Xlsxtream
   class Columns
 
@@ -18,7 +17,7 @@ module Xlsxtream
     end
 
     def to_xml
-      xml = '<cols>'
+      xml = String.new('<cols>')
 
       @columns.each_with_index do |column, index|
         width_chars  = column[ :width_chars  ]

--- a/lib/xlsxtream/errors.rb
+++ b/lib/xlsxtream/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   class Error < StandardError; end
   class Deprecation < StandardError; end

--- a/lib/xlsxtream/io/directory.rb
+++ b/lib/xlsxtream/io/directory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "pathname"
 
 module Xlsxtream

--- a/lib/xlsxtream/io/hash.rb
+++ b/lib/xlsxtream/io/hash.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   module IO
     class Hash

--- a/lib/xlsxtream/io/rubyzip.rb
+++ b/lib/xlsxtream/io/rubyzip.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "zip"
 require "xlsxtream/errors"
 

--- a/lib/xlsxtream/io/stream.rb
+++ b/lib/xlsxtream/io/stream.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   module IO
     class Stream

--- a/lib/xlsxtream/io/zip_tricks.rb
+++ b/lib/xlsxtream/io/zip_tricks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "zip_tricks"
 
 module Xlsxtream
@@ -8,7 +9,7 @@ module Xlsxtream
       def initialize(body)
         @streamer = ::ZipTricks::Streamer.new(body)
         @wf = nil
-        @buffer = ''
+        @buffer = String.new
       end
 
       def <<(data)

--- a/lib/xlsxtream/row.rb
+++ b/lib/xlsxtream/row.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 require "date"
 require "xlsxtream/xml"
 
@@ -27,8 +27,8 @@ module Xlsxtream
     end
 
     def to_xml
-      column = 'A'
-      xml = %Q{<row r="#{@rownum}">}
+      column = String.new('A')
+      xml = String.new(%Q{<row r="#{@rownum}">})
 
       @row.each do |value|
         cid = "#{column}#{@rownum}"

--- a/lib/xlsxtream/shared_string_table.rb
+++ b/lib/xlsxtream/shared_string_table.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   class SharedStringTable < Hash
     def initialize

--- a/lib/xlsxtream/version.rb
+++ b/lib/xlsxtream/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   VERSION = '2.1.0'.freeze
 end

--- a/lib/xlsxtream/workbook.rb
+++ b/lib/xlsxtream/workbook.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 require "xlsxtream/errors"
 require "xlsxtream/xml"
 require "xlsxtream/shared_string_table"
@@ -105,7 +105,7 @@ module Xlsxtream
     end
 
     def write_workbook
-      rid = "rId0"
+      rid = String.new("rId0")
       @io.add_file "xl/workbook.xml"
       @io << XML.header
       @io << XML.strip(<<-XML)
@@ -185,7 +185,7 @@ module Xlsxtream
     end
 
     def write_workbook_rels
-      rid = "rId0"
+      rid = String.new("rId0")
       @io.add_file "xl/_rels/workbook.xml.rels"
       @io << XML.header
       @io << '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'

--- a/lib/xlsxtream/worksheet.rb
+++ b/lib/xlsxtream/worksheet.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 require "xlsxtream/xml"
 require "xlsxtream/row"
 

--- a/lib/xlsxtream/xml.rb
+++ b/lib/xlsxtream/xml.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Xlsxtream
   module XML
     XML_ESCAPES = {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'xlsxtream'
 

--- a/test/xlsxtream/columns_test.rb
+++ b/test/xlsxtream/columns_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/row'
 

--- a/test/xlsxtream/io/directory_test.rb
+++ b/test/xlsxtream/io/directory_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/io/directory'
 require 'pathname'

--- a/test/xlsxtream/io/hash_test.rb
+++ b/test/xlsxtream/io/hash_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'stringio'
 require 'xlsxtream/io/hash'

--- a/test/xlsxtream/io/rubyzip_test.rb
+++ b/test/xlsxtream/io/rubyzip_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/io/rubyzip'
 require 'zip'

--- a/test/xlsxtream/io/stream_test.rb
+++ b/test/xlsxtream/io/stream_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'stringio'
 require 'xlsxtream/io/stream'

--- a/test/xlsxtream/io/zip_tricks_test.rb
+++ b/test/xlsxtream/io/zip_tricks_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/io/zip_tricks'
 require 'zip'

--- a/test/xlsxtream/row_test.rb
+++ b/test/xlsxtream/row_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/row'
 

--- a/test/xlsxtream/shared_string_table_test.rb
+++ b/test/xlsxtream/shared_string_table_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/shared_string_table'
 

--- a/test/xlsxtream/workbook_test.rb
+++ b/test/xlsxtream/workbook_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'stringio'
 require 'tempfile'

--- a/test/xlsxtream/worksheet_test.rb
+++ b/test/xlsxtream/worksheet_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'stringio'
 require 'xlsxtream/worksheet'

--- a/test/xlsxtream/xml_test.rb
+++ b/test/xlsxtream/xml_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'xlsxtream/xml'
 

--- a/test/xlsxtream_test.rb
+++ b/test/xlsxtream_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class XlsxtreamTest < Minitest::Test

--- a/xlsxtream.gemspec
+++ b/xlsxtream.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'xlsxtream/version'


### PR DESCRIPTION
This ensures that the gem works properly with `--enable-frozen-string-literal` and makes all source code enable frozen strings if supported.

Note that the tests that depend on rubyzip fail with --enable-frozen-string-literal` because rubyzip 1.2.1 mutates strings used as buffers.