### PR TITLE
Encode empty values

### DIFF
--- a/lib/xlsxtream/row.rb
+++ b/lib/xlsxtream/row.rb
@@ -52,14 +52,12 @@ module Xlsxtream
         else
           value = value.to_s
 
-          unless value.empty? # no xml output for for empty strings
-            value = value.encode(ENCODING) if value.encoding != ENCODING
+          value = value.encode(ENCODING) if value.encoding != ENCODING
 
-            if @sst
-              xml << %Q{<c r="#{cid}" t="s"><v>#{@sst[value]}</v></c>}
-            else
-              xml << %Q{<c r="#{cid}" t="inlineStr"><is><t>#{XML.escape_value(value)}</t></is></c>}
-            end
+          if @sst
+            xml << %Q{<c r="#{cid}" t="s"><v>#{@sst[value]}</v></c>}
+          else
+            xml << %Q{<c r="#{cid}" t="inlineStr"><is><t>#{XML.escape_value(value)}</t></is></c>}
           end
         end
       end

--- a/test/xlsxtream/row_test.rb
+++ b/test/xlsxtream/row_test.rb
@@ -6,7 +6,7 @@ module Xlsxtream
   class RowTest < Minitest::Test
     def test_empty_column
       row = Row.new([nil], 1)
-      expected = '<row r="1"></row>'
+      expected = '<row r="1"><c r="A1" t="inlineStr"><is><t></t></is></c></row>'
       actual = row.to_xml
       assert_equal expected, actual
     end
@@ -148,7 +148,7 @@ module Xlsxtream
 
     def test_multiple_columns
       row = Row.new(['foo', nil, 23], 1)
-      expected = '<row r="1"><c r="A1" t="inlineStr"><is><t>foo</t></is></c><c r="C1" t="n"><v>23</v></c></row>'
+      expected = '<row r="1"><c r="A1" t="inlineStr"><is><t>foo</t></is></c><c r="B1" t="inlineStr"><is><t></t></is></c><c r="C1" t="n"><v>23</v></c></row>'
       actual = row.to_xml
       assert_equal expected, actual
     end


### PR DESCRIPTION
The original library skips processing of empty cells, but this behavior
is not desirable for us. There is an [issue reported][1] about it and a
[PR fixing it][2], but the upstream author has not acted on it.

This is the reason we decided to fork the repository and patch it
manually. Credit goes to the patch's author for his work.

JRVS-300