### PR TITLE
Switch dependency to zip_kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0 (2020-06-27)
+
+- Change dependency from zip_tricks to zip_kit
+
 ## 2.4.0 (2020-06-27)
 
 - Allow writing worksheets without a block using add\_worksheet (#42, #45)

--- a/lib/xlsxtream/io/zip_kit.rb
+++ b/lib/xlsxtream/io/zip_kit.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
-require "zip_tricks"
+require "zip_kit"
 
 module Xlsxtream
   module IO
-    class ZipTricks
+    class ZipKit
       BUFFER_SIZE = 64 * 1024
 
       def initialize(body)
-        @streamer = ::ZipTricks::Streamer.new(body)
+        @streamer = ::ZipKit::Streamer.new(body)
         @wf = nil
         @buffer = String.new
       end

--- a/lib/xlsxtream/workbook.rb
+++ b/lib/xlsxtream/workbook.rb
@@ -3,7 +3,7 @@ require "xlsxtream/errors"
 require "xlsxtream/xml"
 require "xlsxtream/shared_string_table"
 require "xlsxtream/worksheet"
-require "xlsxtream/io/zip_tricks"
+require "xlsxtream/io/zip_kit"
 
 module Xlsxtream
   class Workbook
@@ -46,13 +46,13 @@ module Xlsxtream
       end
       if output.is_a?(String) || !output.respond_to?(:<<)
         @file = File.open(output, 'wb')
-        @io = IO::ZipTricks.new(@file)
+        @io = IO::ZipKit.new(@file)
       elsif output.respond_to? :add_file
         @file = nil
         @io = output
       else
         @file = nil
-        @io = IO::ZipTricks.new(output)
+        @io = IO::ZipKit.new(output)
       end
       @sst = SharedStringTable.new
       @worksheets = []

--- a/test/xlsxtream/io/zip_tricks_test.rb
+++ b/test/xlsxtream/io/zip_tricks_test.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 require 'test_helper'
-require 'xlsxtream/io/zip_tricks'
+require 'xlsxtream/io/zip_kit'
 require 'zip'
 
 module Xlsxtream
-  class ZipTricksTest < Minitest::Test
+  class ZipKitTest < Minitest::Test
 
     def test_writes_of_multiple_files
       zip_buf = Tempfile.new('ztio-test')
 
-      io = Xlsxtream::IO::ZipTricks.new(zip_buf)
+      io = Xlsxtream::IO::ZipKit.new(zip_buf)
       io.add_file("book1.xml")
       io << '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook />'
       io.add_file("book2.xml")

--- a/xlsxtream.gemspec
+++ b/xlsxtream.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1.0"
 
-  spec.add_dependency "zip_tricks", ">= 4.5", "< 6"
+  spec.add_dependency "zip_kit", ">= 6.2", "< 7"
 
   spec.add_development_dependency "bundler", ">= 1.7", "< 3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
ZipKit has been forked from ZipTricks... same maintainer and code is the same, just been renamed. 

ZIpTricks will no longer receive updates.

https://github.com/WeTransfer/zip_tricks
https://github.com/julik/zip_kit

This PR simply makes the switchover.